### PR TITLE
Throw error if missing source id when it's required

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -334,10 +334,6 @@ exports.init = (Sequelize, sequelize, optionsArg) => {
 						? ns.get(options.continuationKey)
 						: opt[options.continuationKey];
 
-				if (!source) {
-					return Promise.resolve();
-				}
-
 				const sourceType = source.constructor.name;
 				const sourceId = source.id;
 				const { transaction } = opt;


### PR DESCRIPTION
We should throw errors if audit trail should be required for a model. 